### PR TITLE
Readme cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Add [Typescript](https://github.com/microsoft/typescript) Webpack loading to a [`react-app-rewired`](https://github.com/timarney/react-app-rewired) config.
 
 ```js
-const rewireTypescriptPlugin = require('react-app-rewire-typescript')
+const rewireTypescript = require('react-app-rewire-typescript')
 
 // Add Typescript support
 config = rewireTypescript(config, env)

--- a/README.md
+++ b/README.md
@@ -3,10 +3,16 @@
 Add [Typescript](https://github.com/microsoft/typescript) Webpack loading to a [`react-app-rewired`](https://github.com/timarney/react-app-rewired) config.
 
 ```js
-const rewireTypescript = require('react-app-rewire-typescript')
+/* config-overrides.js */
 
-// Add Typescript support
-config = rewireTypescript(config, env)
+const rewireTypescript = require('react-app-rewire-typescript');
+
+module.exports = function override(config, env) {
+    // ...
+    config = rewireTypescript(config, env);
+    // ...
+    return config;
+}
 ```
 
 For running `.ts` test files, take a look at [`ts-jest`](https://github.com/kulshekhar/ts-jest). PRs to integrate `ts-jest` compatibility into this repo are welcome.


### PR DESCRIPTION
I fixed a variable name typo. I also thought it was easer it understand the example when demonstrated a more complete `config-overrides.js` file.