### PR TITLE
Update file-loader rule filter

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function rewireTypescript(config, env, typescriptLoaderOptions = {}) {
     rule =>
       rule.loader &&
       typeof rule.loader === 'string' &&
-      rule.loader.endsWith(`file-loader${path.sep}index.js`)
+      rule.loader.indexOf(`${path.sep}file-loader${path.sep}`) !== -1
   )
   fileLoader.exclude.push(/\.tsx?$/)
 


### PR DESCRIPTION
This broke in react-scripts 1.0.15. The path to the file-loader distribution now contains a subdirectory. I opted to omit it and specify a full directory name rather than follow the change.

Also, I think the intention in the default react-scripts webconfiguration is for file-loader to be a catch-all as the last rule in the oneOf nested rule. An alternative approach that may be more conventional (and therefore safer) with the upstream changes in react-scripts could be to insert the TypeScript rule before the file-loader rule and not add the TypeScript exclude to file-loader at all. For now this will fix the issue with current versions of react-scripts without changing the approach in this rewire.

Let's discuss it in here if you'd like:
timarney/react-app-rewired#127